### PR TITLE
Sample improvements

### DIFF
--- a/products-subgraph/src/main/java/com/example/products/ProductsController.java
+++ b/products-subgraph/src/main/java/com/example/products/ProductsController.java
@@ -6,7 +6,6 @@ import org.springframework.graphql.data.method.annotation.QueryMapping;
 import org.springframework.stereotype.Controller;
 
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;

--- a/products-subgraph/src/test/java/com/example/products/ProductsApplicationTest.java
+++ b/products-subgraph/src/test/java/com/example/products/ProductsApplicationTest.java
@@ -2,26 +2,21 @@ package com.example.products;
 
 import com.example.products.model.Product;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.web.server.LocalServerPort;
-import org.springframework.graphql.test.tester.HttpGraphQlTester;
-import org.springframework.test.web.reactive.server.WebTestClient;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.graphql.tester.AutoConfigureHttpGraphQlTester;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.graphql.test.tester.HttpGraphQlTester;
+
+@AutoConfigureHttpGraphQlTester
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class ProductsApplicationTest {
 
-  @LocalServerPort
-  int serverPort;
+  @Autowired
+  private HttpGraphQlTester tester;
 
   @Test
   public void verifiesProductQuery() {
-    WebTestClient testClient = WebTestClient.bindToServer()
-      .baseUrl("http://localhost:" + serverPort + "/graphql")
-      .build();
-    HttpGraphQlTester tester = HttpGraphQlTester.create(testClient);
-
     String query = """
       query ProductById($productId: ID!) {
         product(id: $productId) {

--- a/reviews-subgraph/src/main/java/com/example/reviews/ReviewsController.java
+++ b/reviews-subgraph/src/main/java/com/example/reviews/ReviewsController.java
@@ -19,7 +19,7 @@ public class ReviewsController {
     "5", List.of(new Review("1050", "Amazing! Would Fly Again!", 5), new Review("1051", 5))
   );
 
-  @SchemaMapping(typeName="Product", field="reviews")
+  @SchemaMapping
   public List<Review> reviews(Product show) {
     return REVIEWS.getOrDefault(show.id(), Collections.emptyList());
   }

--- a/reviews-subgraph/src/test/java/com/example/reviews/ReviewsApplicationTest.java
+++ b/reviews-subgraph/src/test/java/com/example/reviews/ReviewsApplicationTest.java
@@ -4,24 +4,20 @@ import com.example.reviews.model.Review;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.graphql.tester.AutoConfigureHttpGraphQlTester;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.graphql.test.tester.HttpGraphQlTester;
-import org.springframework.test.web.reactive.server.WebTestClient;
 
+@AutoConfigureHttpGraphQlTester
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class ReviewsApplicationTest {
 
-  @LocalServerPort
-  int serverPort;
+  @Autowired
+  private HttpGraphQlTester tester;
 
   @Test
   public void verifiesProductQuery() {
-    WebTestClient testClient = WebTestClient.bindToServer()
-      .baseUrl("http://localhost:" + serverPort + "/graphql")
-      .build();
-    HttpGraphQlTester tester = HttpGraphQlTester.create(testClient);
-
     String query = """
       query Entities($representations: [_Any!]!) {
         _entities(representations: $representations) {


### PR DESCRIPTION
The following improvements in separate commits:

- Use `@AutoConfigureHttpGraphQlTester` in tests to have the tester initialized by Boot.
- Remove attributes from `@SchemaMapping` in `ReviewsController` since default conventions match in this case.
- Use `ClassNameTypeResolver` in the config for reviews. It handles straight forward type mappings and is customizable.